### PR TITLE
Add ability to replace mainPom and attach a list of artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ This plugin is meant to be a small collection of helpers to smooth the migration
 The `main-artifact` Goal
 ------------------------
 
-The `main-artifact` goal simply sets the file of the project's main artifact.
+The `main-artifact` goal can set the file of the project's main artifact and main pom file. It can also attach auxillary artifacts to be deployed (in the same way as the build-helper-maven-plugin)
+
+| Parameters | Type | Required | Description |
+| ---------- | ---- | -------- | ----------- |
+| mainArtifact | String | Yes | File path to the new main artifact to deploy |
+| mainPom | String | No | File path to the replacement main pom to deploy |
+| artifacts | Artifact[] | No | Attach an array of artifacts to the project |
 
 This can be useful if you're wrapping another build system's output with Maven pom.xml files, and need to get Maven to recognize the build output for purposes of installation or deployment. Its use is very simple:
 
@@ -34,7 +40,7 @@ This can be useful if you're wrapping another build system's output with Maven p
           <plugin>
             <groupId>org.commonjava.maven.plugins</groupId>
             <artifactId>build-migration-maven-plugin</artifactId>
-            <version>0.1</version>
+            <version>0.4</version>
             <executions>
               <execution>
                 <id>main-artifact</id>
@@ -43,6 +49,14 @@ This can be useful if you're wrapping another build system's output with Maven p
                 </goals>
                 <configuration>
                   <mainArtifact>build/project-1.1.jar</mainArtifact>
+                  <mainPom>resources/myproject.pom</mainPom>
+                  <artifacts>
+                    <artifact>
+                      <file>myproject-sources.jar</file>
+                      <type>jar</type>
+                      <classifier>sources</classifier>
+                    </artifact>
+                  </artifacts>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -77,8 +82,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.9</version>
+        <version>3.4</version>
         <executions>
+          <execution>
+            <id>descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
           <execution>
             <id>generated-helpmojo</id>
             <goals>

--- a/src/main/java/org/commonjava/maven/plugins/migrate/Artifact.java
+++ b/src/main/java/org/commonjava/maven/plugins/migrate/Artifact.java
@@ -1,0 +1,116 @@
+package org.commonjava.maven.plugins.migrate;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import java.io.File;
+
+/**
+ * <p>
+ * Artifact class.
+ * </p>
+ *
+ * @author dtran
+ * @version $Id$
+ */
+public class Artifact
+{
+    private File file;
+
+    private String type = "jar";
+
+    private String classifier;
+
+    /**
+     * <p>
+     * Setter for the field <code>file</code>.
+     * </p>
+     *
+     * @param localFile a {@link File} object.
+     */
+    public void setFile( File localFile )
+    {
+        this.file = localFile;
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>file</code>.
+     * </p>
+     *
+     * @return a {@link File} object.
+     */
+    public File getFile()
+    {
+        return this.file;
+    }
+
+    /**
+     * <p>
+     * Setter for the field <code>type</code>.
+     * </p>
+     *
+     * @param type a {@link String} object.
+     */
+    public void setType( String type )
+    {
+        this.type = type;
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>type</code>.
+     * </p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getType()
+    {
+        return this.type;
+    }
+
+    /**
+     * <p>
+     * Setter for the field <code>classifier</code>.
+     * </p>
+     *
+     * @param classifier a {@link String} object.
+     */
+    public void setClassifier( String classifier )
+    {
+        this.classifier = classifier;
+    }
+
+    /**
+     * <p>
+     * Getter for the field <code>classifier</code>.
+     * </p>
+     *
+     * @return a {@link String} object.
+     */
+    public String getClassifier()
+    {
+        return this.classifier;
+    }
+}


### PR DESCRIPTION
This is useful for the case where we have an Ant build that generates its own pom, jar, javadoc and sources. 